### PR TITLE
Change library to use hidapi-lwt

### DIFF
--- a/ledgerwallet-ssh-agent.opam
+++ b/ledgerwallet-ssh-agent.opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.4.0"}
   "ledgerwallet"
   "hex" { with-test }
-  "alcotest" { with-test }
+  "alcotest-lwt" { with-test }
 ]
 synopsis: "Ledger wallet library for OCaml: SSH agent app"
 description: """

--- a/ledgerwallet-tezos.opam
+++ b/ledgerwallet-tezos.opam
@@ -16,7 +16,7 @@ depends: [
   "uecc" { with-test }
   "hex" { with-test }
   "secp256k1" # { with-test } # commented because github actions does not install external deps for test only deps
-  "alcotest" { with-test }
+  "alcotest-lwt" { with-test }
 ]
 synopsis: "Ledger wallet library for OCaml: Tezos app"
 description:"""

--- a/ledgerwallet-zil.opam
+++ b/ledgerwallet-zil.opam
@@ -15,7 +15,7 @@ depends: [
   "hex" {>= "1.4.0"}
   "bech32"
   "ledgerwallet"
-  "alcotest" { with-test }
+  "alcotest-lwt" { with-test }
 ]
 synopsis: "Ledger wallet library for OCaml: Zilliqa app"
 description:"""

--- a/ledgerwallet.opam
+++ b/ledgerwallet.opam
@@ -14,7 +14,8 @@ depends: [
   "dune" {>= "2.4.0"}
   "rresult" {>= "0.6.0"}
   "cstruct" {>= "6.0.0"}
-  "hidapi" {>= "1.1.1"}
+  "hidapi-lwt" {>= "1.1.3"}
+  "lwt" {>= "5.7.0"}
 ]
 synopsis: "Ledger wallet library for OCaml"
 description: """Library to communicate with Ledger hardware wallets

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
  (public_name ledgerwallet)
  (modules Apdu Status Transport_hidapi Transport_proxy Transport)
  (synopsis "Ledger wallet library for OCaml: common parts")
- (libraries rresult cstruct hidapi))
+ (libraries rresult cstruct hidapi-lwt))
 
 (library
  (name ledgerwallet_btc)

--- a/src/ledgerwallet_ssh_agent.ml
+++ b/src/ledgerwallet_ssh_agent.ml
@@ -3,7 +3,7 @@
    Distributed under the ISC license, see terms at the end of the file.
   ---------------------------------------------------------------------------*)
 
-open Rresult
+open Lwt_result.Infix
 open Ledgerwallet
 
 type ins =
@@ -45,7 +45,7 @@ let get_public_key ?pp ?buf ~curve ~path h =
     ?buf
     h
     Apdu.(create ~lc ~p2 ~data:data_init (wrap_ins Get_public_key))
-  >>| fun addr ->
+  >|= fun addr ->
   let keylen = Cstruct.get_uint8 addr 0 in
   Cstruct.sub addr 1 keylen
 

--- a/src/ledgerwallet_ssh_agent.mli
+++ b/src/ledgerwallet_ssh_agent.mli
@@ -13,7 +13,7 @@ val get_public_key :
   curve:curve ->
   path:int32 list ->
   Ledgerwallet.Transport.t ->
-  (Cstruct.t, Ledgerwallet.Transport.error) result
+  (Cstruct.t, Ledgerwallet.Transport.error) result Lwt.t
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2017 Vincent Bernardoff

--- a/src/ledgerwallet_tezos.ml
+++ b/src/ledgerwallet_tezos.ml
@@ -261,14 +261,14 @@ let get_all_high_watermarks ?pp ?buf h =
     let main_hwm_round = Cstruct.BE.get_uint32 data 4 in
     let test_hwm = Cstruct.BE.get_uint32 data 8 in
     let test_hwm_round = Cstruct.BE.get_uint32 data 12 in
-    let chain_id = Cstruct.copy data 16 4 in
+    let chain_id = Cstruct.to_string data ~off:16 ~len:4 in
     ( `Main_hwm (main_hwm, Some main_hwm_round),
       `Test_hwm (test_hwm, Some test_hwm_round),
       `Chain_id chain_id )
   else
     let main_hwm = Cstruct.BE.get_uint32 data 0 in
     let test_hwm = Cstruct.BE.get_uint32 data 4 in
-    let chain_id = Cstruct.copy data 8 4 in
+    let chain_id = Cstruct.to_string data ~off:8 ~len:4 in
     (`Main_hwm (main_hwm, None), `Test_hwm (test_hwm, None), `Chain_id chain_id)
 
 let set_high_watermark ?pp ?buf h hwm =

--- a/src/ledgerwallet_tezos.mli
+++ b/src/ledgerwallet_tezos.mli
@@ -31,7 +31,7 @@ val get_version :
   ?pp:Format.formatter ->
   ?buf:Cstruct.t ->
   Ledgerwallet.Transport.t ->
-  (Version.t, Transport.error) result
+  (Version.t, Transport.error) result Lwt.t
 
 (** [get_git_commit ?pp ?buf ledger] is the git commit information of
     the Ledger app running at [ledger]. *)
@@ -39,7 +39,7 @@ val get_git_commit :
   ?pp:Format.formatter ->
   ?buf:Cstruct.t ->
   Ledgerwallet.Transport.t ->
-  (string, Transport.error) result
+  (string, Transport.error) result Lwt.t
 
 (** [get_authorized_key ?pp ?buf ledger] is the BIP32 path of the key
     authorized to bake on the Ledger app running at [ledger]. *)
@@ -47,7 +47,7 @@ val get_authorized_key :
   ?pp:Format.formatter ->
   ?buf:Cstruct.t ->
   Ledgerwallet.Transport.t ->
-  (int32 list, Transport.error) result
+  (int32 list, Transport.error) result Lwt.t
 
 (** [get_authorized_path_and_curve ?pp ?buf ledger] is the BIP32 path
     and the curve code of the key authorized to bake on the Ledger app
@@ -56,7 +56,7 @@ val get_authorized_path_and_curve :
   ?pp:Format.formatter ->
   ?buf:Cstruct.t ->
   Ledgerwallet.Transport.t ->
-  (int32 list * curve, Transport.error) result
+  (int32 list * curve, Transport.error) result Lwt.t
 
 (** [get_public_key ?pp ?buf ?prompt ledger curve path] is [0x02 ||
     pk] from [ledger] at [path] for curve [curve]. If [prompt] is
@@ -69,7 +69,7 @@ val get_public_key :
   Ledgerwallet.Transport.t ->
   curve ->
   int32 list ->
-  (Cstruct.t, Transport.error) result
+  (Cstruct.t, Transport.error) result Lwt.t
 
 (** [authorize_baking ?pp ?buf ?prompt ledger curve path] is like
     [get_public_key] with [prompt = true], but only works with the
@@ -83,7 +83,7 @@ val authorize_baking :
   Ledgerwallet.Transport.t ->
   curve ->
   int32 list ->
-  (Cstruct.t, Transport.error) result
+  (Cstruct.t, Transport.error) result Lwt.t
 
 (** [setup_baking ?pp ?buf ?prompt ledger ~main_chain_id ~main_hwm ~test_hwm curve path]
     sets up the Ledger's Baking application: it informs
@@ -100,7 +100,7 @@ val setup_baking :
   test_hwm:int32 ->
   curve ->
   int32 list ->
-  (Cstruct.t, Transport.error) result
+  (Cstruct.t, Transport.error) result Lwt.t
 
 (** [deauthorize_baking ?pp ?buf ledger]
     deauthorizes the Ledger's Baking application from baking for any address. *)
@@ -108,7 +108,7 @@ val deauthorize_baking :
   ?pp:Format.formatter ->
   ?buf:Cstruct.t ->
   Ledgerwallet.Transport.t ->
-  (unit, Transport.error) result
+  (unit, Transport.error) result Lwt.t
 
 (** [get_high_watermark ?pp ?buf ledger] is the current value of the
     high water mark for the main-chain on [ledger]. This works with
@@ -118,7 +118,7 @@ val get_high_watermark :
   ?pp:Format.formatter ->
   ?buf:Cstruct.t ->
   Ledgerwallet.Transport.t ->
-  (int32 * int32 option, Transport.error) result
+  (int32 * int32 option, Transport.error) result Lwt.t
 
 (** Query the high water marks for the main and test chains, as well as the ID
     of the main-chain (string of length 4) recorded by the Ledger Baking app. *)
@@ -131,6 +131,7 @@ val get_all_high_watermarks :
     * [`Chain_id of string],
     Transport.error )
   result
+  Lwt.t
 
 (** [set_high_watermark ?pp ?buf ledger hwm] reset the high water
     mark on [ledger] to [hwm] for the main-chain.
@@ -141,7 +142,7 @@ val set_high_watermark :
   ?buf:Cstruct.t ->
   Ledgerwallet.Transport.t ->
   int32 ->
-  (unit, Transport.error) result
+  (unit, Transport.error) result Lwt.t
 
 (** [sign ?pp ?buf ?hash_on_ledger h curve path payload] is the
     signature of [payload] (or its hash if [hash_on_ledger] is [true],
@@ -155,7 +156,7 @@ val sign :
   curve ->
   int32 list ->
   Cstruct.t ->
-  (Cstruct.t, Transport.error) result
+  (Cstruct.t, Transport.error) result Lwt.t
 
 (** [get_deterministic_nonce ?pp ?buf h curve path payload] asks the ledger
     for a deterministic nonce from a some given bytes (using HMAC).
@@ -167,7 +168,7 @@ val get_deterministic_nonce :
   curve ->
   int32 list ->
   Cstruct.t ->
-  (Cstruct.t, Transport.error) result
+  (Cstruct.t, Transport.error) result Lwt.t
 
 (** [sign ?pp ?buf ?hash_on_ledger h curve path payload] is the
     signature of [payload] (or its hash if [hash_on_ledger] is [true],
@@ -180,7 +181,7 @@ val sign_and_hash :
   curve ->
   int32 list ->
   Cstruct.t ->
-  (Cstruct.t * Cstruct.t, Transport.error) result
+  (Cstruct.t * Cstruct.t, Transport.error) result Lwt.t
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2017 Vincent Bernardoff

--- a/src/ledgerwallet_zil.ml
+++ b/src/ledgerwallet_zil.ml
@@ -3,7 +3,7 @@
    Distributed under the ISC license, see terms at the end of the file.
   ---------------------------------------------------------------------------*)
 
-open Rresult
+open Lwt_result.Infix
 open Ledgerwallet
 
 type ins = Get_version | Get_public_key | Sign_hash | Sign_txn
@@ -20,7 +20,7 @@ let wrap_ins cmd =
 let get_version ?pp ?buf h =
   let msg = "Zil.get_version" in
   let apdu = Apdu.create (wrap_ins Get_version) in
-  Transport.apdu ~msg ?pp ?buf h apdu >>| fun ver ->
+  Transport.apdu ~msg ?pp ?buf h apdu >|= fun ver ->
   Cstruct.(get_uint8 ver 0, get_uint8 ver 1, get_uint8 ver 2)
 
 let get_pk ?(display_addr = false) ?pp ?buf h i =
@@ -29,7 +29,7 @@ let get_pk ?(display_addr = false) ?pp ?buf h i =
   Cstruct.LE.set_uint32 data 0 i ;
   let p2 = if display_addr then 1 else 0 in
   let apdu = Apdu.create ~p2 ~data (wrap_ins Get_public_key) in
-  Transport.apdu ~msg ?pp ?buf h apdu >>| fun buf ->
+  Transport.apdu ~msg ?pp ?buf h apdu >|= fun buf ->
   let pk = Cstruct.sub buf 0 33 in
   let buf = Cstruct.shift buf 33 in
   (pk, Bech32.Segwit.(decode_exn (module Zil) (Cstruct.to_string buf)))

--- a/src/ledgerwallet_zil.mli
+++ b/src/ledgerwallet_zil.mli
@@ -7,7 +7,7 @@ val get_version :
   ?pp:Format.formatter ->
   ?buf:Cstruct.t ->
   Ledgerwallet.Transport.t ->
-  (int * int * int, Ledgerwallet.Transport.error) result
+  (int * int * int, Ledgerwallet.Transport.error) result Lwt.t
 
 val get_pk :
   ?display_addr:bool ->
@@ -16,6 +16,7 @@ val get_pk :
   Ledgerwallet.Transport.t ->
   int32 ->
   (Cstruct.t * [`Zil] Bech32.Segwit.t, Ledgerwallet.Transport.error) result
+  Lwt.t
 
 (** data must be a 32 bytes-len hash. *)
 val sign_hash :
@@ -24,7 +25,7 @@ val sign_hash :
   Ledgerwallet.Transport.t ->
   int32 ->
   Cstruct.t ->
-  (Cstruct.t, Ledgerwallet.Transport.error) result
+  (Cstruct.t, Ledgerwallet.Transport.error) result Lwt.t
 
 (** data can be arbitrary len. *)
 val sign_txn :
@@ -33,7 +34,7 @@ val sign_txn :
   Ledgerwallet.Transport.t ->
   int32 ->
   Cstruct.t ->
-  (Cstruct.t, Ledgerwallet.Transport.error) result
+  (Cstruct.t, Ledgerwallet.Transport.error) result Lwt.t
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2019 Vincent Bernardoff

--- a/src/transport.mli
+++ b/src/transport.mli
@@ -15,26 +15,30 @@ type proxy_path
 
 type path = Hidapi_path of Hidapi.device_info | Proxy_path of proxy_path
 
-val enumerate : unit -> path list
+val enumerate : unit -> path list Lwt.t
 
 val app_error : msg:string -> ('a, Status.t) result -> ('a, error) result
 
 val pp_error : Format.formatter -> error -> unit
 
-val open_id : vendor_id:int -> product_id:int -> t option
+val open_id : vendor_id:int -> product_id:int -> t option Lwt.t
 
-val open_path : path -> t option
+val open_path : path -> t option Lwt.t
 
-val close : t -> unit
+val close : t -> unit Lwt.t
 
 val with_connection_id :
-  vendor_id:int -> product_id:int -> (t -> 'a) -> 'a option
+  vendor_id:int -> product_id:int -> (t -> 'a Lwt.t) -> 'a option Lwt.t
 
-val with_connection_path : path -> (t -> 'a) -> 'a option
+val with_connection_path : path -> (t -> 'a Lwt.t) -> 'a option Lwt.t
 
 (** [write_apdu ?pp ?buf ledger apdu] writes [apdu] to [ledger]. *)
 val write_apdu :
-  ?pp:Format.formatter -> ?buf:Cstruct.t -> t -> Apdu.t -> (unit, error) result
+  ?pp:Format.formatter ->
+  ?buf:Cstruct.t ->
+  t ->
+  Apdu.t ->
+  (unit, error) result Lwt.t
 
 (** [read ?pp ?buf ledger] reads from [ledger] a status response and a
     payload. *)
@@ -42,11 +46,12 @@ val read :
   ?pp:Format.formatter ->
   ?buf:Cstruct.t ->
   t ->
-  (Status.t * Cstruct.t, error) result
+  (Status.t * Cstruct.t, error) result Lwt.t
 
 (** [ping ?pp ?buf ledger] writes a ping packet to [ledger],
     optionally containing [buf]. *)
-val ping : ?pp:Format.formatter -> ?buf:Cstruct.t -> t -> (unit, error) result
+val ping :
+  ?pp:Format.formatter -> ?buf:Cstruct.t -> t -> (unit, error) result Lwt.t
 
 (** [apdu ?pp ?msg ?buf ledger apdu] writes [apdu] to [ledger] and
     returns the response. *)
@@ -56,7 +61,7 @@ val apdu :
   ?buf:Cstruct.t ->
   t ->
   Apdu.t ->
-  (Cstruct.t, error) result
+  (Cstruct.t, error) result Lwt.t
 
 (** [write_payload ?pp ?msg ?buf ?mark_last ~cmd ?p1 ?p2 ledger
     payload] writes the [payload] of [cmd] into [ledger] and returns
@@ -71,7 +76,7 @@ val write_payload :
   ?p2:int ->
   t ->
   Cstruct.t ->
-  (Cstruct.t, error) result
+  (Cstruct.t, error) result Lwt.t
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2017 Vincent Bernardoff

--- a/src/transport_hidapi.mli
+++ b/src/transport_hidapi.mli
@@ -13,7 +13,7 @@ val write_apdu :
   ?buf:Cstruct.t ->
   Hidapi.t ->
   Apdu.t ->
-  (unit, error) result
+  (unit, error) result Lwt.t
 
 (** [read ?pp ?buf ledger] reads from [ledger] a status response and a
     payload. *)
@@ -21,12 +21,15 @@ val read :
   ?pp:Format.formatter ->
   ?buf:Cstruct.t ->
   Hidapi.t ->
-  (Status.t * Cstruct.t, error) result
+  (Status.t * Cstruct.t, error) result Lwt.t
 
 (** [ping ?pp ?buf ledger] writes a ping packet to [ledger],
     optionally containing [buf]. *)
 val ping :
-  ?pp:Format.formatter -> ?buf:Cstruct.t -> Hidapi.t -> (unit, error) result
+  ?pp:Format.formatter ->
+  ?buf:Cstruct.t ->
+  Hidapi.t ->
+  (unit, error) result Lwt.t
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2017 Vincent Bernardoff

--- a/test/dune
+++ b/test/dune
@@ -8,16 +8,16 @@
  (name test_tezos)
  (modules Test_tezos)
  (package ledgerwallet-tezos)
- (libraries alcotest ledgerwallet-tezos secp256k1 uecc))
+ (libraries alcotest-lwt ledgerwallet-tezos secp256k1 uecc))
 
 (test
  (name test_zil)
  (modules Test_zil)
  (package ledgerwallet-zil)
- (libraries hex alcotest ledgerwallet-zil))
+ (libraries hex alcotest-lwt ledgerwallet-zil))
 
 (test
  (name test_ssh_agent)
  (modules Test_ssh_agent)
  (package ledgerwallet-ssh-agent)
- (libraries hex alcotest ledgerwallet-ssh-agent))
+ (libraries hex alcotest-lwt ledgerwallet-ssh-agent))

--- a/test/test_ssh_agent.ml
+++ b/test/test_ssh_agent.ml
@@ -1,21 +1,27 @@
-open Rresult
 open Ledgerwallet_ssh_agent
+open Lwt_result.Infix
 
-let fail_on_error = function
-  | None -> Alcotest.fail "Found no ledger."
-  | Some (Result.Ok ()) -> ()
-  | Some (Result.Error e) ->
-      Alcotest.fail
-        (Format.asprintf "Ledger error: %a" Ledgerwallet.Transport.pp_error e)
+let return_unit = Lwt.return_ok ()
 
-let with_connection f =
+let fail_on_error x =
+  Lwt.bind x (function
+      | None -> Alcotest.fail "Found no ledger."
+      | Some (Ok ()) -> Lwt.return_unit
+      | Some (Error e) ->
+          Alcotest.fail
+            (Format.asprintf
+               "Ledger error: %a"
+               Ledgerwallet.Transport.pp_error
+               e))
+
+let with_connection (f : _ -> 'a Lwt.t) =
   fail_on_error
     (Ledgerwallet.Transport.with_connection_id
        ~vendor_id:0x2C97
        ~product_id:0x1005
        f)
 
-let test_open_close () = with_connection (fun _ -> R.ok ())
+let test_open_close () = with_connection (fun _ -> return_unit)
 
 let test_ping () = with_connection Ledgerwallet.Transport.ping
 
@@ -26,7 +32,7 @@ let path = [hard 44l; hard 535348l]
 let test_get_public_key () =
   with_connection (fun h ->
       get_public_key h ~curve:Prime256v1 ~path >>= fun pk_prime ->
-      get_public_key h ~curve:Curve25519 ~path >>| fun pk_curve ->
+      get_public_key h ~curve:Curve25519 ~path >|= fun pk_curve ->
       Format.printf
         "Uncompressed prime256v1 public key %a@."
         Hex.pp
@@ -43,4 +49,5 @@ let basic =
     ("get_public_key", `Quick, test_get_public_key);
   ]
 
-let () = Alcotest.run "ledgerwallet.ssh-agent" [("basic", basic)]
+let () =
+  Lwt_main.run @@ Alcotest_lwt.(run "ledgerwallet.ssh-agent" [("basic", basic)])


### PR DESCRIPTION
This PR is a follow-up of https://github.com/vbmithr/ocaml-hidapi/pull/4 introducing hidapi-lwt. All hidapi calls are replaced by their hidapi-lwt counterparts which changes the monad from result to lwt_result.